### PR TITLE
Fix version incompatibility issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(name='tap-exchangeratesapi',
       url='http://singer.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_exchangeratesapi'],
-      install_requires=['singer-python>=5.1.0',
+      install_requires=['singer-python==5.3.3',
                         'backoff==1.3.2',
                         'requests==2.13.0'],
       entry_points='''

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(name='tap-exchangeratesapi',
       url='http://singer.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_exchangeratesapi'],
-      install_requires=['singer-python>=0.1.0',
+      install_requires=['singer-python>=5.1.0',
                         'backoff==1.3.2',
                         'requests==2.13.0'],
       entry_points='''


### PR DESCRIPTION
This package does not work with older versions of the `singer-python` package. Ensure this package is required as part of future installations (or using `pip`'s `--upgrade` flag).

This fix avoids tracebacks such as the following:
```
root@e61cc5f7db82:/usr/local/project# tap-exchangeratesapi | target-csv
Traceback (most recent call last):
  File "/usr/local/bin/tap-exchangeratesapi", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.6/site-packages/tap_exchangeratesapi.py", line 102, in main
    start_date = singer.utils.strptime_with_tz(start_date).date().strftime(DATE_FORMAT)
AttributeError: module 'singer.utils' has no attribute 'strptime_with_tz'
```