### PR TITLE
Discard API responses that do not match the requested date

### DIFF
--- a/tap_exchangeratesapi.py
+++ b/tap_exchangeratesapi.py
@@ -61,7 +61,8 @@ def do_sync(base, start_date):
             if datetime.strptime(next_date, DATE_FORMAT) > datetime.utcnow():
                 break
             else:
-                singer.write_records('exchange_rate', [parse_response(payload)])
+                if payload['date'] == next_date:
+                    singer.write_records('exchange_rate', [parse_response(payload)])
                 state = {'start_date': next_date}
                 next_date = (datetime.strptime(next_date, DATE_FORMAT) + timedelta(days=1)).strftime(DATE_FORMAT)
 


### PR DESCRIPTION
Only write the record when the API response date matches the request date. Fix for #2 