### PR TITLE
Add optional --discover capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Byte-compiled / optimized / DLL files
+.mypy_cache
 __pycache__/
 *.py[cod]
 *$py.class

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ __pycache__/
 *.so
 
 # Distribution / packaging
+.output
 .Python
 env/
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# IDE settings:
+.vscode
+
 # C extensions
 *.so
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# CSV output files
+
+exchange_rate-*.csv
+
 # Byte-compiled / optimized / DLL files
 .mypy_cache
 __pycache__/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "[ptyhon]": {
+        // Prevent auto-format until `black` auto-formatter is adopted:
+        "editor.formatOnSave": false
+    },
+    "editor.formatOnSave": false,
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "[ptyhon]": {
-        // Prevent auto-format until `black` auto-formatter is adopted:
-        "editor.formatOnSave": false
-    },
-    "editor.formatOnSave": false,
-}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include tap_exchangeratesapi/schemas/*.json

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-exchangeratesapi',
-      version='0.1.1',
+      version='0.2.0',
       description='Singer.io tap for extracting currency exchange rate data from the exchangeratesapi.io API',
       author='Stitch',
       url='http://github.com/singer-io/tap-exchangeratesapi',

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,9 @@ setup(name='tap-exchangeratesapi',
       url='http://github.com/singer-io/tap-exchangeratesapi',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_exchangeratesapi'],
-      install_requires=['singer-python==5.3.3',
-                        'backoff==1.3.2',
-                        'requests==2.21.0'],
+      install_requires=['singer-python==5.8.0',
+                        'backoff==1.8.0',
+                        'requests==2.22.0'],
       extras_require={
           'dev': [
               'ipdb==0.11'

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,6 @@ setup(name='tap-exchangeratesapi',
           tap-exchangeratesapi=tap_exchangeratesapi:main
       ''',
       packages=['tap_exchangeratesapi'],
+      package_data={"schemas": ["tap_exchangeratesapi/schemas/*.json"]},
       include_package_data=True
 )

--- a/tap_exchangeratesapi/__init__.py
+++ b/tap_exchangeratesapi/__init__.py
@@ -102,7 +102,7 @@ def do_sync(base, start_date, catalog_override: Dict[str, Any] = None):
                             singer.Transformer().transform(
                                 data=record,
                                 schema=catalog_stream_override[0]["schema"],
-                                # metadata=metadata_override, # TODO: debug (not working)
+                                metadata=catalog_stream_override[0],
                             )
                         )
                 else:

--- a/tap_exchangeratesapi/__init__.py
+++ b/tap_exchangeratesapi/__init__.py
@@ -127,13 +127,13 @@ def main():
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
-        '-d', '--discover', help='Do schema discovery', required=False, action='store_true')
+        '-d', '--discover', help='Do schema discovery (optional).', required=False, action='store_true')
     parser.add_argument(
-        '-c', '--config', help='Config file', required=False)
+        '-c', '--config', help='Optional config file.', required=False)
     parser.add_argument(
-        '-s', '--state', help='State file', required=False)
+        '-s', '--state', help='Optional state file.', required=False)
     parser.add_argument(
-        '--catalog', help='Catalog file', required=False)
+        '--catalog', help='Optional catalog file.', required=False)
 
     args = parser.parse_args()
 

--- a/tap_exchangeratesapi/discovery.py
+++ b/tap_exchangeratesapi/discovery.py
@@ -17,7 +17,7 @@ def _get_abs_path(path):
 
 
 # Load schemas from schemas folder
-def _load_schemas():
+def _load_stream_schemas():
     schemas = {}
     for filename in os.listdir(_get_abs_path("schemas")):
         path = _get_abs_path("schemas") + "/" + filename
@@ -38,13 +38,13 @@ def discover() -> Dict[str, Dict[str, Any]]:
     """
     LOGGER.info("Starting discovery mode")
     streams = []
-    for stream_name, schema in _load_schemas().items():
+    for stream_name, stream in _load_stream_schemas().items():
         catalog_entry = {
             "stream": stream_name,
             "tap_stream_id": stream_name,
-            "schema": schema,
+            "schema": stream["schema"],
             "metadata": metadata.get_standard_metadata(
-                schema=schema["schema"],
+                schema=stream["schema"],
                 key_properties=["date"],
                 valid_replication_keys=["date"],
                 replication_method=REPLICATION_METHOD,

--- a/tap_exchangeratesapi/discovery.py
+++ b/tap_exchangeratesapi/discovery.py
@@ -1,0 +1,55 @@
+"""Discovery functions for the Singer.io tap"""
+
+import json
+import os
+
+import singer
+from singer import Catalog, metadata
+
+from typing import Dict, List, Any
+
+LOGGER = singer.get_logger()
+REPLICATION_METHOD = "INCREMENTAL"
+
+
+def _get_abs_path(path):
+    return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
+
+
+# Load schemas from schemas folder
+def _load_schemas():
+    schemas = {}
+    for filename in os.listdir(_get_abs_path("schemas")):
+        path = _get_abs_path("schemas") + "/" + filename
+        basename = filename.replace(".json", "")
+        with open(path) as file:
+            schemas[basename] = json.load(file)
+    return schemas
+
+
+def discover() -> Dict[str, Dict[str, Any]]:
+    """
+    Run discovery
+
+    Returns
+    -------
+    Dict[str, Dict[str, Any]]
+        The list of streams with their associated metadata
+    """
+    LOGGER.info("Starting discovery mode")
+    streams = []
+    for stream_name, schema in _load_schemas().items():
+        catalog_entry = {
+            "stream": stream_name,
+            "tap_stream_id": stream_name,
+            "schema": schema,
+            "metadata": metadata.get_standard_metadata(
+                schema=schema["schema"],
+                key_properties=["date"],
+                valid_replication_keys=["date"],
+                replication_method=REPLICATION_METHOD,
+            ),
+            "key_properties": ["date"],
+        }
+        streams.append(catalog_entry)
+    return Catalog.from_dict({"streams": streams})

--- a/tap_exchangeratesapi/schemas/exchange_rate.json
+++ b/tap_exchangeratesapi/schemas/exchange_rate.json
@@ -1,0 +1,56 @@
+{
+  "stream": "exchange_rate",
+  "tap_stream_id": "exchange_rate",
+  "schema": {
+    "type": "object",
+    "properties": {
+      "date": { "type": "string", "format": "date-time" },
+      "CAD": { "type": ["null", "number"] },
+      "HKD": { "type": ["null", "number"] },
+      "ISK": { "type": ["null", "number"] },
+      "PHP": { "type": ["null", "number"] },
+      "DKK": { "type": ["null", "number"] },
+      "HUF": { "type": ["null", "number"] },
+      "CZK": { "type": ["null", "number"] },
+      "GBP": { "type": ["null", "number"] },
+      "RON": { "type": ["null", "number"] },
+      "SEK": { "type": ["null", "number"] },
+      "IDR": { "type": ["null", "number"] },
+      "INR": { "type": ["null", "number"] },
+      "BRL": { "type": ["null", "number"] },
+      "RUB": { "type": ["null", "number"] },
+      "HRK": { "type": ["null", "number"] },
+      "JPY": { "type": ["null", "number"] },
+      "THB": { "type": ["null", "number"] },
+      "CHF": { "type": ["null", "number"] },
+      "EUR": { "type": ["null", "number"] },
+      "MYR": { "type": ["null", "number"] },
+      "BGN": { "type": ["null", "number"] },
+      "TRY": { "type": ["null", "number"] },
+      "CNY": { "type": ["null", "number"] },
+      "NOK": { "type": ["null", "number"] },
+      "NZD": { "type": ["null", "number"] },
+      "ZAR": { "type": ["null", "number"] },
+      "USD": { "type": ["null", "number"] },
+      "MXN": { "type": ["null", "number"] },
+      "SGD": { "type": ["null", "number"] },
+      "AUD": { "type": ["null", "number"] },
+      "ILS": { "type": ["null", "number"] },
+      "KRW": { "type": ["null", "number"] },
+      "PLN": { "type": ["null", "number"] }
+    }
+  },
+  "metadata": [
+    {
+      "metadata": {
+        "table-key-properties": ["date"],
+        "valid-replication-keys": ["date"],
+        "is-view": false,
+        "selected": true,
+        "replication-method": "INCREMENTAL"
+      },
+      "breadcrumb": []
+    }
+  ],
+  "key_properties": ["date"]
+}


### PR DESCRIPTION
# Description of change

This PR adds _**(optional)**_ discovery capability. This is a broadly used tap and care must be taken to avoid breaking existing samples.

In order to not break downstream consumers and samples:

- [x] Sync must run with or without the `--catalog` argument provided.
- [x] Discovery must produce equivalent schema as would otherwise be emitted during tap's `sync` operation.
- [ ] When `--catalog` or `-c` argument _is_ provided, the tap should respect the singer spec, for instance column selections.

# Manual QA steps

 - [x] executed using `--discover` flag and confirmed emitted json matches with expected schema.
 - [x] (not done) Run sync with or without the provided catalog.
 - [ ] (not done) Run sync with the primary stream deselected; confirm that no data is emitted.
 - [ ] (not done) Run sync with specific columns deselected; confirm that ignored column data is omitted.
 
# Risks

 - Would break critical samples and onboarding if merged with breaking changes.
 
# Rollback steps

 - revert this branch
