### PR TITLE
Exchangerates-API requieres access key

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,78 @@ data from [exchangeratesapi.io](http://exchangeratesapi.io).
 ---
 
 Copyright &copy; 2017 Stitch
+
+### config.json:
+```
+{
+    "base": "AUD",
+    "start_date": "2017-02-02",
+    "api_key": "123abc456def"
+}
+
+```
+
+### state.json
+```
+{"start_date": "2021-03-31"}
+```
+
+## Installation
+### Prepare Server
+
+1. Installation of Ubuntu 18.04
+2. Install python 3.7.1 from source code
+```
+sudo apt update
+sudo apt install build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget
+cd /tmp
+wget https://www.python.org/ftp/python/3.7.1/Python-3.7.1.tgz
+tar –xf Python-3.7.1.tgz
+```
+
+Info: https://phoenixnap.com/kb/how-to-install-python-3-ubuntu
+
+3. Install pip3
+See here: https://linuxize.com/post/how-to-install-pip-on-ubuntu-18.04/
+
+4. Install setuptools for pip
+```
+pip install setuptools
+```
+
+### Create python environments
+We use different environments for each pymodul from singer.io to avoid version conflicts
+1. Create tap-exchangeratesapi environment
+```
+#Create environment
+python3 -m venv .virtualenvs/tap-exchangeratesapi
+#Activate environment
+source .virtualenvs/tap-exchangeratesapi/bin/activate
+# Go to exchangeratesapi repo
+cd tap-exchangeratesapi
+#Install requierements
+pip install -r requirements.txt
+# Install tap-exchangeratesapi as py modul in environment
+python setup.py build --force
+python setup.py install
+```
+
+2. Create environment for target for example stitch or csv
+```
+# Install target-stitch in its own virtualenv
+python3 -m venv .virtualenvs/target-stitch
+source .virtualenvs/target-stitch/bin/activate
+pip install target-stitch
+deactivate
+
+
+# Install target-csv in its own virtualenv
+python3 -m venv .virtualenvs/target-csv
+source .virtualenvs/target-csv/bin/activate
+pip install target-csv
+deactivate
+```
+
+## EXECUTE THE PACKAGE (with a target)
+
+.virtualenvs/tap-exchangeratesapi/bin/tap-exchangeratesapi --config "config_fil" --state "state-file" | .virtualenvs/target-csv/bin/target-csv

--- a/config.sample.json
+++ b/config.sample.json
@@ -1,4 +1,5 @@
 {
     "base": "AUD",
-    "start_date": "2017-02-02"
+    "start_date": "2017-02-02",
+    "api_key": "123abc456def"
 }

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-
-from setuptools import setup, find_packages
+from setuptools import setup
 
 setup(name='tap-exchangeratesapi',
       version='0.1.1',

--- a/tap_exchangeratesapi/__init__.py
+++ b/tap_exchangeratesapi/__init__.py
@@ -11,7 +11,7 @@ import copy
 
 from datetime import date, datetime, timedelta
 
-base_url = 'https://api.exchangeratesapi.io/'
+base_url = 'http://api.exchangeratesapi.io/'
 
 logger = singer.get_logger()
 session = requests.Session()
@@ -46,7 +46,7 @@ def request(url, params):
     response.raise_for_status()
     return response
     
-def do_sync(base, start_date):
+def do_sync(base, start_date, access_key):
     state = {'start_date': start_date}
     next_date = start_date
     prev_schema = {}
@@ -57,8 +57,10 @@ def do_sync(base, start_date):
                         next_date,
                         base)
 
-            response = request(base_url + next_date, {'base': base})
+            response = request(base_url + next_date, {'base': base, 'access_key': access_key})
             payload = response.json()
+
+            logger.info(payload)
 
             # Update schema if new currency/currencies exist
             for rate in payload['rates']:
@@ -111,8 +113,9 @@ def main():
 
     start_date = state.get('start_date') or config.get('start_date') or datetime.utcnow().strftime(DATE_FORMAT)
     start_date = singer.utils.strptime_with_tz(start_date).date().strftime(DATE_FORMAT)
+    access_key = config.get('access_key')
 
-    do_sync(config.get('base', 'USD'), start_date)
+    do_sync(config.get('base', 'USD'), start_date, access_key)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Exchangrerates API requieres an access key to work. It does not work anymore since 01.04.2021 without this key. 

The README has been enhanced as well to show the users how to implement and test it.

# Description of change
- Changed the base url to "HTTP" instead of "HTTPS" as the lowest plan (Free plan) from exchangeratesapi.io only provieds "HTTP"
- Added access_key as parameter in `do_sync` and used this parameter in the `request` method
- Added payload logging to be able to trace the responses and understand what has been done
- Read access_key from config file and pass it as parameter in `do_sync` call

# Manual QA steps
 - Tested locally 
 
# Risks
 - Error while executing without api_key but users without the API key will not be able to run this tap anyway.
 
# Rollback steps
 - revert this branch
