### PR TITLE
Add sleep and additional logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,74 @@ data from [exchangeratesapi.io](http://exchangeratesapi.io).
 
 ---
 
-Copyright &copy; 2017 Stitch
+### config.json:
+```
+{
+    "base": "AUD",
+    "start_date": "2017-02-02",
+    "api_key": "123abc456def"
+}
+```
+
+### state.json
+```
+{"start_date": "2021-03-31"}
+```
+
+## Installation
+### Prepare Server
+
+1. Installation of Ubuntu 18.04
+2. Install python 3.7.1 from source code
+```
+sudo apt update
+sudo apt install build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget
+cd /tmp
+wget https://www.python.org/ftp/python/3.7.1/Python-3.7.1.tgz
+tar –xf Python-3.7.1.tgz
+```
+
+Info: https://phoenixnap.com/kb/how-to-install-python-3-ubuntu
+
+3. Install pip3
+See here: https://linuxize.com/post/how-to-install-pip-on-ubuntu-18.04/
+
+4. Install setuptools for pip
+```
+pip install setuptools
+```
+
+### Create python environments
+We use different environments for each pymodul from singer.io to avoid version conflicts
+1. Create tap-exchangeratesapi environment
+```
+#Create environment
+python3 -m venv .virtualenvs/tap-exchangeratesapi
+#Activate environment
+source .virtualenvs/tap-exchangeratesapi/bin/activate
+# Go to exchangeratesapi repo
+cd tap-exchangeratesapi
+#Install requierements
+pip install -r requirements.txt
+# Install tap-exchangeratesapi as py modul in environment
+python setup.py build --force
+python setup.py install
+```
+
+2. Create environment for target for example stitch or csv
+```
+# Install target-stitch in its own virtualenv
+python3 -m venv .virtualenvs/target-stitch
+source .virtualenvs/target-stitch/bin/activate
+pip install target-stitch
+deactivate
+# Install target-csv in its own virtualenv
+python3 -m venv .virtualenvs/target-csv
+source .virtualenvs/target-csv/bin/activate
+pip install target-csv
+deactivate
+```
+
+## EXECUTE THE PACKAGE (with a target)
+
+.virtualenvs/tap-exchangeratesapi/bin/tap-exchangeratesapi --config "config_fil" --state "state-file" | .virtualenvs/target-csv/bin/target-csv

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,7 @@ setup(name='tap-exchangeratesapi',
       url='http://github.com/singer-io/tap-exchangeratesapi',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_exchangeratesapi'],
-      install_requires=['singer-python==5.3.3',
-                        'backoff==1.3.2',
+      install_requires=['pipelinewise-singer-python==1.1.3',
                         'requests==2.21.0'],
       extras_require={
           'dev': [

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-exchangeratesapi',
-      version='0.1.1',
+      version='0.1.3',
       description='Singer.io tap for extracting currency exchange rate data from the exchangeratesapi.io API',
       author='Stitch',
       url='http://github.com/singer-io/tap-exchangeratesapi',

--- a/tap_exchangeratesapi/__init__.py
+++ b/tap_exchangeratesapi/__init__.py
@@ -11,7 +11,7 @@ import copy
 
 from datetime import date, datetime, timedelta
 
-base_url = 'https://api.exchangeratesapi.io/'
+base_url = 'http://api.exchangeratesapi.io/'
 
 logger = singer.get_logger()
 session = requests.Session()
@@ -46,7 +46,7 @@ def request(url, params):
     response.raise_for_status()
     return response
     
-def do_sync(base, start_date):
+def do_sync(base, start_date, access_key):
     state = {'start_date': start_date}
     next_date = start_date
     prev_schema = {}
@@ -57,7 +57,7 @@ def do_sync(base, start_date):
                         next_date,
                         base)
 
-            response = request(base_url + next_date, {'base': base})
+            response = request(base_url + next_date, {'base': base, 'access_key': access_key})
             payload = response.json()
 
             # Update schema if new currency/currencies exist
@@ -111,8 +111,9 @@ def main():
 
     start_date = state.get('start_date') or config.get('start_date') or datetime.utcnow().strftime(DATE_FORMAT)
     start_date = singer.utils.strptime_with_tz(start_date).date().strftime(DATE_FORMAT)
+    access_key = config.get('access_key')
 
-    do_sync(config.get('base', 'USD'), start_date)
+    do_sync(config.get('base', 'USD'), start_date, access_key)
 
 
 if __name__ == '__main__':

--- a/tap_exchangeratesapi/__init__.py
+++ b/tap_exchangeratesapi/__init__.py
@@ -45,12 +45,12 @@ def request(url, params):
     response = requests.get(url=url, params=params)
     response.raise_for_status()
     return response
-    
+
 def do_sync(base, start_date, access_key):
     state = {'start_date': start_date}
     next_date = start_date
     prev_schema = {}
-    
+
     try:
         while datetime.strptime(next_date, DATE_FORMAT) <= datetime.utcnow():
             logger.info('Replicating exchange rate data from %s using base %s',
@@ -59,10 +59,12 @@ def do_sync(base, start_date, access_key):
 
             response = request(base_url + next_date, {'base': base, 'access_key': access_key})
             payload = response.json()
+            logger.info(f"Payload: {payload}")
 
             # Update schema if new currency/currencies exist
             for rate in payload['rates']:
                 if rate not in schema['properties']:
+                    logger.info(f"Updating schema properties with {rate}")
                     schema['properties'][rate] = {'type': ['null', 'number']}
 
             # Only write schema if it has changed
@@ -70,6 +72,7 @@ def do_sync(base, start_date, access_key):
                 singer.write_schema('exchange_rate', schema, 'date')
 
             if payload['date'] == next_date:
+                logger.info(f"Writing the payload for {next_date}")
                 singer.write_records('exchange_rate', [parse_response(payload)])
 
             state = {'start_date': next_date}

--- a/tap_exchangeratesapi/__init__.py
+++ b/tap_exchangeratesapi/__init__.py
@@ -12,6 +12,7 @@ import copy
 from datetime import date, datetime, timedelta
 
 base_url = 'http://api.exchangeratesapi.io/'
+SECONDS_BETWEEN_REQUESTS = 70
 
 logger = singer.get_logger()
 session = requests.Session()
@@ -64,7 +65,6 @@ def do_sync(base, start_date, access_key):
             # Update schema if new currency/currencies exist
             for rate in payload['rates']:
                 if rate not in schema['properties']:
-                    logger.info(f"Updating schema properties with {rate}")
                     schema['properties'][rate] = {'type': ['null', 'number']}
 
             # Only write schema if it has changed
@@ -72,13 +72,14 @@ def do_sync(base, start_date, access_key):
                 singer.write_schema('exchange_rate', schema, 'date')
 
             if payload['date'] == next_date:
-                logger.info(f"Writing the payload for {next_date}")
+                logger.info(f"Writing the data for {next_date}")
                 singer.write_records('exchange_rate', [parse_response(payload)])
 
             state = {'start_date': next_date}
             next_date = (datetime.strptime(next_date, DATE_FORMAT) + timedelta(days=1)).strftime(DATE_FORMAT)
             prev_schema = copy.deepcopy(schema)
-            time.sleep(70)
+            logger.info(f"Sleeping for {SECONDS_BETWEEN_REQUESTS} seconds")
+            time.sleep(SECONDS_BETWEEN_REQUESTS)
 
     except requests.exceptions.RequestException as e:
         logger.fatal('Error on ' + e.request.url +

--- a/tap_exchangeratesapi/__init__.py
+++ b/tap_exchangeratesapi/__init__.py
@@ -78,6 +78,7 @@ def do_sync(base, start_date, access_key):
             state = {'start_date': next_date}
             next_date = (datetime.strptime(next_date, DATE_FORMAT) + timedelta(days=1)).strftime(DATE_FORMAT)
             prev_schema = copy.deepcopy(schema)
+            time.sleep(70)
 
     except requests.exceptions.RequestException as e:
         logger.fatal('Error on ' + e.request.url +


### PR DESCRIPTION
After turning additional logging, it turned out that the first request is going through, while the second one is hitting the rate limits of the API. In the documentation it says:

> The Free Plan is set out to be a "trial version" without a time limit, offering some basic API functionalities, such as making API Requests, getting regular data updates, accessing historical data, and requesting specific currencies.
> 
> Paid Subscription Plans feature significantly higher API Request volumes and data updates as often as every 60 seconds, ensure secure data streams via 256-bit HTTPS Encryption, include unlimited and prioritised technical support, and offer a variety of must-have API functionalities.

Which hinted me that we need more than 60-seconds refresh times